### PR TITLE
[WIP] add generic handler to simple message for a group in workplace

### DIFF
--- a/server/handlers/errors.go
+++ b/server/handlers/errors.go
@@ -1,0 +1,11 @@
+package handlers
+
+// Errors in string format useful to handle in Serve function
+const (
+	EMissingData            = "missing data in body"
+	EUnreadableBodyFmt      = "can't read body: %s"
+	EUnexpectedBodyFmt      = "can't unmarshal %s from body: %s"
+	ERequest                = "Error returned on request to api: %s"
+	EUnexpectedStatus       = "unexpected status returned from api: %s"
+	EUnexpectedEmptyMessage = "unexpected empty message returned"
+)

--- a/server/handlers/generic/generic.go
+++ b/server/handlers/generic/generic.go
@@ -1,0 +1,71 @@
+package generic
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/bornlogic/wiw/server/handlers"
+	"github.com/bornlogic/wiw/server/models/generic"
+	"github.com/bornlogic/wiw/workplace"
+	"github.com/julienschmidt/httprouter"
+)
+
+// NewHandler create a new generic handler with a internal group sender for Serve usage
+func NewHandler(gsender workplace.GroupSender) *handler {
+	return &handler{gsender}
+}
+
+// handler is the abstraction about generic handler
+type handler struct {
+	gsender workplace.GroupSender
+}
+
+// Serve receives a generic message to send to a given groupID
+func (h *handler) Serve(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if r.Body == http.NoBody {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, handlers.EMissingData)
+		return
+	}
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusNotAcceptable)
+		fmt.Fprintf(w, handlers.EUnreadableBodyFmt, err)
+		return
+	}
+	defer r.Body.Close()
+
+	var (
+		message string
+		groupID = ps.ByName("groupID")
+	)
+
+	var payload generic.Payload
+	if err := json.Unmarshal(b, &payload); err != nil {
+		w.WriteHeader(handlers.StatusResponseNotExpected)
+		fmt.Fprintf(w, handlers.EUnexpectedBodyFmt, "issues", err)
+		return
+	}
+	message = payload.ToMarkdown()
+
+	if message == "" {
+		fmt.Fprintf(w, handlers.EUnexpectedBodyFmt, "generic", handlers.EUnexpectedEmptyMessage)
+		return
+	}
+
+	resp, err := h.gsender.Send(groupID, message)
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintf(w, handlers.ERequest, err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintf(w, handlers.EUnexpectedStatus, resp.Status)
+		return
+	}
+}

--- a/server/handlers/github/github_test.go
+++ b/server/handlers/github/github_test.go
@@ -9,6 +9,7 @@ import (
 
 	"strings"
 
+	"github.com/bornlogic/wiw/server/handlers"
 	"github.com/bornlogic/wiw/server/handlers/github"
 	"github.com/julienschmidt/httprouter"
 )
@@ -45,14 +46,14 @@ var githubServeTests = []struct {
 		name:     "missing body",
 		event:    "whatever",
 		wantCode: http.StatusBadRequest,
-		wantErr:  github.EMissingData,
+		wantErr:  handlers.EMissingData,
 	},
 	{
 		name:     "invalid body",
 		event:    "whatever",
 		bodyVal:  "badReader",
 		wantCode: http.StatusNotAcceptable,
-		wantErr:  fmt.Sprintf(github.EUnreadableBodyFmt, EReaderErr),
+		wantErr:  fmt.Sprintf(handlers.EUnreadableBodyFmt, EReaderErr),
 	},
 
 	// Event not mapped
@@ -69,7 +70,7 @@ var githubServeTests = []struct {
 		event:    "issues",
 		bodyVal:  "invalid",
 		wantCode: github.StatusResponseNotExpected,
-		wantErr: fmt.Sprintf(github.EUnexpectedBodyFmt, "issues",
+		wantErr: fmt.Sprintf(handlers.EUnexpectedBodyFmt, "issues",
 			"invalid character 'i' looking for beginning of value"),
 	},
 	{
@@ -77,7 +78,7 @@ var githubServeTests = []struct {
 		event:    "pull_request",
 		bodyVal:  "invalid",
 		wantCode: github.StatusResponseNotExpected,
-		wantErr: fmt.Sprintf(github.EUnexpectedBodyFmt, "pull_request",
+		wantErr: fmt.Sprintf(handlers.EUnexpectedBodyFmt, "pull_request",
 			"invalid character 'i' looking for beginning of value"),
 	},
 	{
@@ -85,7 +86,7 @@ var githubServeTests = []struct {
 		event:    "push",
 		bodyVal:  "invalid",
 		wantCode: github.StatusResponseNotExpected,
-		wantErr: fmt.Sprintf(github.EUnexpectedBodyFmt, "push",
+		wantErr: fmt.Sprintf(handlers.EUnexpectedBodyFmt, "push",
 			"invalid character 'i' looking for beginning of value"),
 	},
 
@@ -126,7 +127,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"action": "whatever"}`,
 		gsenderType: "error",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.ERequest, "error"),
+		wantErr:     fmt.Sprintf(handlers.ERequest, "error"),
 	},
 	{
 		name:        "error sent from pull_request",
@@ -134,7 +135,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"action": "whatever"}`,
 		gsenderType: "error",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.ERequest, "error"),
+		wantErr:     fmt.Sprintf(handlers.ERequest, "error"),
 	},
 	{
 		name:        "error sent from push in master",
@@ -142,7 +143,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"ref": "refs/heads/master"}`,
 		gsenderType: "error",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.ERequest, "error"),
+		wantErr:     fmt.Sprintf(handlers.ERequest, "error"),
 	},
 
 	// Invalid status code returned from api
@@ -152,7 +153,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"action": "whatever"}`,
 		gsenderType: "invalid_status",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.EUnexpectedStatus, "invalid"),
+		wantErr:     fmt.Sprintf(handlers.EUnexpectedStatus, "invalid"),
 	},
 	{
 		name:        "invalid status from pull_request",
@@ -160,7 +161,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"action": "whatever"}`,
 		gsenderType: "invalid_status",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.EUnexpectedStatus, "invalid"),
+		wantErr:     fmt.Sprintf(handlers.EUnexpectedStatus, "invalid"),
 	},
 	{
 		name:        "invalid status from push",
@@ -168,7 +169,7 @@ var githubServeTests = []struct {
 		bodyVal:     `{"ref": "refs/heads/master"}`,
 		gsenderType: "invalid_status",
 		wantCode:    http.StatusServiceUnavailable,
-		wantErr:     fmt.Sprintf(github.EUnexpectedStatus, "invalid"),
+		wantErr:     fmt.Sprintf(handlers.EUnexpectedStatus, "invalid"),
 	},
 }
 

--- a/server/handlers/status.go
+++ b/server/handlers/status.go
@@ -1,0 +1,4 @@
+package handlers
+
+// Custom status code for response not expected
+const StatusResponseNotExpected = 516

--- a/server/models/generic/message.go
+++ b/server/models/generic/message.go
@@ -1,0 +1,16 @@
+package generic
+
+import "fmt"
+
+type Payload struct {
+	Title   string
+	Message string
+}
+
+func (p Payload) ToMarkdown() string {
+	if p.Title == "" && p.Message == "" {
+		return ""
+	}
+	return fmt.Sprintf(`# %s
+%s`, p.Title, p.Message)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 
+	"github.com/bornlogic/wiw/server/handlers/generic"
 	"github.com/bornlogic/wiw/server/handlers/github"
 	"github.com/bornlogic/wiw/workplace"
 	"github.com/julienschmidt/httprouter"
@@ -27,6 +28,9 @@ func NewServer(workplaceAccessToken, formatting string) *server {
 // setupHandlers configure all handlers exposed in server
 func (s *server) setupHandlers() {
 	s.router.POST("/github/:groupID", github.NewHandler(
+		workplace.NewGroupSender(s.workplaceAccessToken, s.formatting),
+	).Serve)
+	s.router.POST("/:groupID", generic.NewHandler(
 		workplace.NewGroupSender(s.workplaceAccessToken, s.formatting),
 	).Serve)
 }


### PR DESCRIPTION
If you send a generic payload with `title` and `message`:
```
{"title": "Here is the title", "message": "Here is the message"}
```

For `<wiw url>/<group id>`

It will Post in group a message
```
# Title
message
```

In workplace